### PR TITLE
Mg gds 14774 - Laravel 11 Upgrade (Allow any guzzle 7 version)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability"                 : "dev",
     "prefer-stable"                     : true,
     "require"                           : {
-        "guzzlehttp/guzzle"             : "7.4.5"
+        "guzzlehttp/guzzle"             : "^7"
     },
     "require-dev"                       : {
         "fzaninotto/faker"              : "1.7.1",


### PR DESCRIPTION
[GDS-14774](https://canddi.atlassian.net/browse/GDS-14774)

This library shouldn't really have so much control about exact versions of guzzle, makes updating this within canddi annoying (as in this case) and in theory should work with any version that doens't jump majors

[GDS-14774]: https://canddi.atlassian.net/browse/GDS-14774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ